### PR TITLE
Add Unifi ports to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - "443:443"
       - "81:81"
       - "8220:8220" # Required for osquery as part of my Fleet deployment https://github.com/kitzy/docker-fleetdm-stack
+      - "3748:3748/udp" # Required for Unifi
+      - "8080:8080" # Required for Unifi
     environment:
       - TZ=${TZ}
     volumes:


### PR DESCRIPTION
Exposed UDP port 3748 and TCP port 8080 in the docker-compose.yml file to support Unifi services.